### PR TITLE
DISCO-6 Hide Osano when embedded

### DIFF
--- a/projects/osano/osano.css
+++ b/projects/osano/osano.css
@@ -34,3 +34,7 @@
     opacity: 1;
   }
 }
+
+.embedded .osano-cm-window {
+  display: none;
+}

--- a/projects/osano/osano.css
+++ b/projects/osano/osano.css
@@ -35,6 +35,6 @@
   }
 }
 
-.embedded .osano-cm-window {
+.os-subcontent .osano-cm-window {
   display: none;
 }


### PR DESCRIPTION
I'll change assignments and assessments to add an "embedded" class to the body when `embedded=true` is passed. Alternative is something more specific like hide-osano but I'm not sure that's needed.